### PR TITLE
Fix smartypants with uvx

### DIFF
--- a/smartypants
+++ b/smartypants
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # Copyright (c) 2025–present Justin Mayer
 # Licensed under the BSD License, for detailed license information, see COPYING
+from __future__ import print_function
 
 """
 ============
@@ -63,8 +64,6 @@ Options
 
   If no ``FILE`` is specified, the input is taken from standard input.
 """
-
-from __future__ import print_function
 
 import argparse
 import sys


### PR DESCRIPTION
Without this change, smartypants doesn't seem to work with `uvx`:

```
$ uvx smartypants
  File "/home/trey/.cache/uv/archive-v0/I-nPK9xPfYPY8uc-Hu7UL/bin/smartypants", line 67
    from __future__ import print_function
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: from __future__ imports must occur at the beginning of the file
```

This may actually be a bug in uvx, but this workaround is small enough that I think it's worth making for now.