### PR TITLE
Don't match > as closing tag within HTML attributes

### DIFF
--- a/smartypants.py
+++ b/smartypants.py
@@ -575,7 +575,22 @@ def _tokenize(text):
 
     tokens = []
 
-    tag_soup = re.compile(r'([^<]*)(<!--.*?--\s*>|<[^>]*>)', re.S)
+    tag_soup = re.compile(r'''
+        ([^<]*)                     # Any text before a tag
+        (                           # The tag itself (a comment or a tag)
+            <!--.*?--\s*>           # HTML comment
+            |                       # OR
+            <                       # Opening angle bracket
+            (?:                     # Non-capturing group (repeated):
+                [^>"']              #   Any char except >, ", or '
+                |                   #   OR
+                "[^"]*"             #   Double-quoted string
+                |                   #   OR
+                '[^']*'             #   Single-quoted string
+            )+                      # (repeated one or more times)
+            >                       # Closing angle bracket
+        )
+    ''', re.DOTALL | re.VERBOSE)
 
     token_match = tag_soup.match(text)
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -171,6 +171,28 @@ document.write('<a href="' + href + '">' + linktext + "</a>");
 
         self.assertLess(end - start, 0.2)
 
+    def test_quotes_in_attributes_with_angle_brackets(self):
+
+        # Arrow function syntax
+        self.assertEqual(
+            sp('<div onclick="() => foo()">text</div>'),
+            '<div onclick="() => foo()">text</div>')
+
+        # Comparison operators
+        self.assertEqual(
+            sp('<div data-condition="a > b">text</div>'),
+            '<div data-condition="a > b">text</div>')
+
+        # Multiple attributes with > characters
+        self.assertEqual(
+            sp('<div data-x="a => b" data-y="c > d">text</div>'),
+            '<div data-x="a => b" data-y="c > d">text</div>')
+
+        # Single quotes too
+        self.assertEqual(
+            sp("<div data-fn='() => x'>text</div>"),
+            "<div data-fn='() => x'>text</div>")
+
 
 def load_tests(loader, tests, pattern):
 


### PR DESCRIPTION
Previously running smartpants against `<div data-condition="a > b">text</div>` would have resulted in the second `"` being converted to a smart quote like `<div data-condition="a > b&#8221;>text</div>`

This fixes that issue and adds a test.

I noticed that the `Makefile` and `setup.py` setup are quite outdated. In case you have trouble testing, note that I had to run `pip install docutils pygments` to run `python setup.py test` successfully.